### PR TITLE
Update Vercel config: change region to iad1

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,22 +1,10 @@
 {
-  "buildCommand": "npm run build",
-  "outputDirectory": ".next",
   "framework": "nextjs",
-  "installCommand": "npm install",
-  "devCommand": "npm run dev",
-  "regions": ["sin1"],
-  "functions": {
-    "src/app/**/*.js": {
-      "runtime": "nodejs18.x"
-    }
-  },
+  "regions": ["iad1"],
   "git": {
     "deploymentEnabled": {
       "production": true,
       "development": true
     }
-  },
-  "github": {
-    "autoAlias": false
   }
 }


### PR DESCRIPTION
Switched deployment region from 'sin1' to 'iad1' and removed build, install, dev commands, functions, and GitHub autoAlias settings for a simplified configuration.